### PR TITLE
prepend @@ to action name

### DIFF
--- a/src/media-query-tracker.js
+++ b/src/media-query-tracker.js
@@ -1,5 +1,5 @@
 const listeners = []
-export const MEDIA_CHANGED = 'rdx-mqt/MEDIA_CHANGED'
+export const MEDIA_CHANGED = '@@rdx-mqt/MEDIA_CHANGED'
 
 // Reducer
 export function reducer(state = {}, action) {


### PR DESCRIPTION
this seems to be a consistent convention (ie. react-router); react-scuttlebutt (ignores actions that begin with an @ symbol); etc.